### PR TITLE
Change storage system + multi worlds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,5 +46,4 @@ bin/
 
 ### runtime world folder ###
 /world/
-/worlds/
-/players/
+/data/

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,5 @@ bin/
 
 ### runtime world folder ###
 /world/
+/worlds/
+/players/

--- a/src/main/kotlin/Bullet.kt
+++ b/src/main/kotlin/Bullet.kt
@@ -6,6 +6,7 @@ import com.aznos.entity.Entity
 import com.aznos.entity.livingentity.LivingEntity
 import com.aznos.entity.player.Player
 import com.aznos.packets.play.out.ServerParticlePacket
+import com.aznos.storage.EmptyStorage
 import com.aznos.storage.StorageManager
 import com.aznos.storage.disk.DiskServerStorage
 import com.aznos.world.data.Particles
@@ -68,7 +69,9 @@ object Bullet : AutoCloseable {
      * if set to false, nothing will save when the server is restarted
      */
     fun createServer(host: String, port: Int = 25565) {
-        storage = StorageManager(DiskServerStorage())
+        storage = StorageManager(
+            if(shouldPersist) DiskServerStorage()
+            else EmptyStorage())
 
         try {
             server = ServerSocket().apply {

--- a/src/main/kotlin/Bullet.kt
+++ b/src/main/kotlin/Bullet.kt
@@ -6,8 +6,9 @@ import com.aznos.entity.Entity
 import com.aznos.entity.livingentity.LivingEntity
 import com.aznos.entity.player.Player
 import com.aznos.packets.play.out.ServerParticlePacket
+import com.aznos.storage.StorageManager
+import com.aznos.storage.disk.DiskServerStorage
 import com.aznos.world.World
-import com.aznos.world.data.Difficulty
 import com.aznos.world.data.Particles
 import com.google.gson.JsonParser
 import dev.dewy.nbt.api.registry.TagTypeRegistry
@@ -23,8 +24,6 @@ import java.io.InputStreamReader
 import java.net.BindException
 import java.net.InetSocketAddress
 import java.net.ServerSocket
-import java.nio.file.Files
-import java.nio.file.Paths
 import java.util.Base64
 import java.util.concurrent.Executors
 import kotlin.time.Duration.Companion.milliseconds
@@ -53,7 +52,8 @@ object Bullet : AutoCloseable {
     val livingEntities = mutableListOf<LivingEntity>()
     val entities = mutableListOf<Entity>()
 
-    val world = World("world")
+    lateinit var storage: StorageManager
+    lateinit var world: World
 
     val breakingBlocks = mutableMapOf<BlockPositionType.BlockPosition, Job>()
     val sprinting = mutableSetOf<Int>()
@@ -69,6 +69,8 @@ object Bullet : AutoCloseable {
      * if set to false, nothing will save when the server is restarted
      */
     fun createServer(host: String, port: Int = 25565) {
+        storage = StorageManager(DiskServerStorage())
+
         try {
             server = ServerSocket().apply {
                 bind(InetSocketAddress(host, port))
@@ -87,10 +89,14 @@ object Bullet : AutoCloseable {
 
         CommandManager.registerCommands()
 
+        // Load world(s)
+        world = storage.getOrLoadWorld("world")
+
         scheduleTimeUpdate()
         scheduleSprintingParticles()
-        if(shouldPersist) scheduleSaveUpdate()
-        loadPersistentData()
+        if(shouldPersist) {
+            scheduleSaveUpdate()
+        }
 
         logger.info("Bullet server started at $host:$port")
 
@@ -102,31 +108,6 @@ object Bullet : AutoCloseable {
                     ClientSession(it).handle()
                 }
             }
-        }
-    }
-
-    /**
-     * Helper function that loads the world data and block data from disk if it exists
-     */
-    private fun loadPersistentData() {
-        if(Files.exists(Paths.get("./${world.name}/data/world.json")) && shouldPersist) {
-            world.readWorldData().let {
-                var difficulty = Difficulty.NORMAL
-                for(diff in Difficulty.entries) {
-                    if(diff.id == it.difficulty) {
-                        difficulty = diff
-                        break
-                    }
-                }
-
-                world.difficulty = difficulty
-                world.weather = if(it.raining) 1 else 0
-                world.timeOfDay = it.timeOfDay
-            }
-        }
-
-        if(Files.exists(Paths.get("./${world.name}/data/blocks.json")) && shouldPersist) {
-            world.modifiedBlocks = world.readBlockData()
         }
     }
 
@@ -152,8 +133,7 @@ object Bullet : AutoCloseable {
             scope.launch {
                 while(isActive) {
                     delay(5.seconds)
-                    world.writeWorldData(world.difficulty, world.weather == 1, world.timeOfDay)
-                    world.writeBlockData(world.modifiedBlocks)
+                    world.save()
                 }
             }
         }
@@ -258,20 +238,11 @@ object Bullet : AutoCloseable {
      * Shuts down the server
      */
     override fun close() {
-        world.writeWorldData(world.difficulty, world.weather == 1, world.timeOfDay)
-        world.writeBlockData(world.modifiedBlocks)
+        for (world in storage.getWorlds()) {
+            world.save()
+        }
 
         for(player in ArrayList(players)) {
-            world.writePlayerData(
-                player.username,
-                player.uuid,
-                player.location,
-                player.status.health,
-                player.status.foodLevel,
-                player.status.saturation,
-                player.status.exhaustion
-            )
-
             player.disconnect(Component.text("Server is shutting down"))
         }
 

--- a/src/main/kotlin/Bullet.kt
+++ b/src/main/kotlin/Bullet.kt
@@ -8,7 +8,6 @@ import com.aznos.entity.player.Player
 import com.aznos.packets.play.out.ServerParticlePacket
 import com.aznos.storage.StorageManager
 import com.aznos.storage.disk.DiskServerStorage
-import com.aznos.world.World
 import com.aznos.world.data.Particles
 import com.google.gson.JsonParser
 import dev.dewy.nbt.api.registry.TagTypeRegistry
@@ -53,7 +52,7 @@ object Bullet : AutoCloseable {
     val entities = mutableListOf<Entity>()
 
     lateinit var storage: StorageManager
-    lateinit var world: World
+    val startupTime = System.currentTimeMillis()
 
     val breakingBlocks = mutableMapOf<BlockPositionType.BlockPosition, Job>()
     val sprinting = mutableSetOf<Int>()
@@ -90,7 +89,7 @@ object Bullet : AutoCloseable {
         CommandManager.registerCommands()
 
         // Load world(s)
-        world = storage.getOrLoadWorld("world")
+        storage.getOrLoadWorld("world")
 
         scheduleTimeUpdate()
         scheduleSprintingParticles()
@@ -119,8 +118,10 @@ object Bullet : AutoCloseable {
             while(isActive) {
                 delay(1.seconds)
 
-                world.timeOfDay = (world.timeOfDay + 20) % 24000
-                world.worldAge += 20
+                for (world in storage.getWorlds()) {
+                    world.timeOfDay = (world.timeOfDay + 20) % 24000
+                    world.worldAge += 20
+                }
             }
         }
     }
@@ -133,7 +134,9 @@ object Bullet : AutoCloseable {
             scope.launch {
                 while(isActive) {
                     delay(5.seconds)
-                    world.save()
+                    for (world in storage.getWorlds()) {
+                        world.save()
+                    }
                 }
             }
         }

--- a/src/main/kotlin/ClientSession.kt
+++ b/src/main/kotlin/ClientSession.kt
@@ -252,9 +252,9 @@ class ClientSession(
      */
     private fun handleHealthDecrease(time: Int): Int {
         with(player.status) {
-            if(foodLevel == 0 && health > 0) {
-                if(time == 4000) {
-                    health -= when(Bullet.world.difficulty) {
+            if(foodLevel <= 0 && health > 0) {
+                if(time >= 4000) {
+                    health -= when(player.world!!.difficulty) {
                         Difficulty.PEACEFUL -> 0
                         Difficulty.EASY -> max(health - 1, 10)
                         Difficulty.NORMAL -> max(health - 1, 1)

--- a/src/main/kotlin/ClientSession.kt
+++ b/src/main/kotlin/ClientSession.kt
@@ -291,7 +291,7 @@ class ClientSession(
         state = GameState.DISCONNECTED
 
         if(state == GameState.PLAY) {
-            if(Bullet.shouldPersist) Bullet.storage.storage.writePlayerData(player)
+            Bullet.storage.storage.writePlayerData(player)
 
             sendPacket(ServerPlayDisconnectPacket(message))
 

--- a/src/main/kotlin/ClientSession.kt
+++ b/src/main/kotlin/ClientSession.kt
@@ -173,15 +173,7 @@ class ClientSession(
                 while(isActive) {
                     delay(5.seconds)
 
-                    Bullet.world.writePlayerData(
-                        player.username,
-                        player.uuid,
-                        player.location,
-                        player.status.health,
-                        player.status.foodLevel,
-                        player.status.saturation,
-                        player.status.exhaustion
-                    )
+                    Bullet.storage.storage.writePlayerData(player)
                 }
             }
         }
@@ -299,15 +291,7 @@ class ClientSession(
         state = GameState.DISCONNECTED
 
         if(state == GameState.PLAY) {
-            Bullet.world.writePlayerData(
-                player.username,
-                player.uuid,
-                player.location,
-                player.status.health,
-                player.status.foodLevel,
-                player.status.saturation,
-                player.status.exhaustion
-            )
+            if(Bullet.shouldPersist) Bullet.storage.storage.writePlayerData(player)
 
             sendPacket(ServerPlayDisconnectPacket(message))
 

--- a/src/main/kotlin/commands/commands/BanCommand.kt
+++ b/src/main/kotlin/commands/commands/BanCommand.kt
@@ -4,8 +4,8 @@ import com.aznos.Bullet
 import com.aznos.commands.CommandCodes
 import com.aznos.commands.commands.suggestions.PlayerSuggestions
 import com.aznos.entity.player.Player
+import com.aznos.entity.player.data.BanData
 import com.aznos.util.DurationFormat.getReadableDuration
-import com.aznos.world.World
 import com.mojang.brigadier.CommandDispatcher
 import com.mojang.brigadier.arguments.StringArgumentType
 import com.mojang.brigadier.builder.LiteralArgumentBuilder
@@ -13,7 +13,6 @@ import com.mojang.brigadier.builder.RequiredArgumentBuilder
 import com.mojang.brigadier.context.CommandContext
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.format.NamedTextColor
-import java.nio.file.Paths
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.hours
@@ -86,12 +85,14 @@ class BanCommand {
         val expirationDuration: Duration? = durationStr?.let { parseTime(it) }
         val readableDuration = getReadableDuration(expirationDuration)
 
-        Bullet.world.writeBannedPlayer(
+        val banData = BanData(
             player.uuid,
             reason,
             expirationDuration ?: Duration.ZERO,
-            context.source.uuid
-        )
+            System.currentTimeMillis(),
+            context.source.uuid)
+
+        Bullet.storage.writeBan(banData)
 
         sendBanMessage(player, readableDuration, reason)
         sendConfirmMessage(context.source, player, readableDuration, reason)

--- a/src/main/kotlin/commands/commands/PerformanceCommand.kt
+++ b/src/main/kotlin/commands/commands/PerformanceCommand.kt
@@ -38,7 +38,9 @@ class PerformanceCommand {
         val threadCount = threadMXBean.threadCount
         val peakThreadCount = threadMXBean.peakThreadCount
         val playerCount = Bullet.players.size
-        val uptime = formatUptime(Bullet.world.worldAge)
+        // TODO create a server wide uptime
+        val rawUptime = System.currentTimeMillis() - Bullet.startupTime
+        val uptime = formatUptime(rawUptime)
 
         return Component.text()
             .append(Component.text("⚡ Server Performance ⚡", NamedTextColor.GOLD, TextDecoration.BOLD))
@@ -67,8 +69,8 @@ class PerformanceCommand {
             .build()
     }
 
-    private fun formatUptime(ticks: Long): String {
-        val totalSeconds = ticks / 20
+    private fun formatUptime(millis: Long): String {
+        val totalSeconds = millis / 1000
         val days = totalSeconds / 86400
         val hours = totalSeconds / 3600
         val minutes = (totalSeconds % 3600) / 60

--- a/src/main/kotlin/commands/commands/UnbanCommand.kt
+++ b/src/main/kotlin/commands/commands/UnbanCommand.kt
@@ -1,7 +1,6 @@
 package com.aznos.commands.commands
 
 import com.aznos.Bullet
-import com.aznos.Bullet.world
 import com.aznos.commands.CommandCodes
 import com.aznos.entity.player.Player
 import com.mojang.brigadier.CommandDispatcher
@@ -13,6 +12,7 @@ import net.kyori.adventure.text.format.NamedTextColor
 import java.util.*
 
 class UnbanCommand {
+
     fun register(dispatcher: CommandDispatcher<Player>) {
         dispatcher.register(
             LiteralArgumentBuilder.literal<Player>("unban")
@@ -22,7 +22,7 @@ class UnbanCommand {
                             val username = StringArgumentType.getString(context, "player")
                             val uuid = UUID.nameUUIDFromBytes(("OfflinePlayer:$username").toByteArray())
 
-                            if(username.equals(context.source.username, true)) {
+                            if (username.equals(context.source.username, true)) {
                                 context.source.sendMessage(
                                     Component.text("You can't unban yourself", NamedTextColor.RED)
                                 )
@@ -30,18 +30,14 @@ class UnbanCommand {
                                 return@executes CommandCodes.ILLEGAL_ARGUMENT.id
                             }
 
-                            val bans = world.readBannedPlayers()
-                            val ban = bans.find { it.uuid == uuid }
-
-                            if(ban == null) {
+                            val ban = Bullet.storage.unbanPlayer(uuid)
+                            if (ban == null) {
                                 context.source.sendMessage(
                                     Component.text("That player is not banned", NamedTextColor.RED)
                                 )
 
                                 return@executes CommandCodes.ILLEGAL_ARGUMENT.id
                             }
-
-                            Bullet.world.unbanPlayer(uuid)
 
                             context.source.sendMessage(
                                 Component.text()
@@ -52,8 +48,9 @@ class UnbanCommand {
                             )
 
                             CommandCodes.SUCCESS.id
-                    }
+                        }
                 )
         )
     }
+
 }

--- a/src/main/kotlin/entity/player/Player.kt
+++ b/src/main/kotlin/entity/player/Player.kt
@@ -27,7 +27,7 @@ class Player(
     lateinit var location: LocationType.Location
     lateinit var locale: String
     lateinit var brand: String
-    var world: World? = Bullet.world
+    var world: World? = Bullet.storage.getWorlds()[0] //TODO better player spawn world initialization
 
     //Inventory and Equipment
     var inventory = Inventory()
@@ -94,8 +94,10 @@ class Player(
      * @param time The time to set it to
      */
     fun setTimeOfDay(time: Long) {
-        world?.timeOfDay = time
-        sendPacket(ServerTimeUpdatePacket(Bullet.world.worldAge, time))
+        if(world == null) return
+
+        world!!.timeOfDay = time
+        sendPacket(ServerTimeUpdatePacket(world!!.worldAge, time))
     }
 
     /**

--- a/src/main/kotlin/packets/PacketHandler.kt
+++ b/src/main/kotlin/packets/PacketHandler.kt
@@ -48,8 +48,6 @@ import packets.handshake.HandshakePacket
 import packets.status.out.ServerStatusResponsePacket
 import java.io.ByteArrayInputStream
 import java.io.DataInputStream
-import java.nio.file.Files
-import java.nio.file.Paths
 import java.time.Instant
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
@@ -757,7 +755,7 @@ class PacketHandler(
 
         sendBlockChanges()
 
-        if(Bullet.shouldPersist) Bullet.storage.storage.writePlayerData(player)
+        Bullet.storage.storage.writePlayerData(player)
 
         val world = player.world!!
         player.setTimeOfDay(world.timeOfDay)
@@ -1020,8 +1018,6 @@ class PacketHandler(
     }
 
     private fun removeBlock(blockPos: BlockPositionType.BlockPosition) {
-        if(!Bullet.shouldPersist) return
-
         val world = world
         if(world.modifiedBlocks.keys.find {
                 it.x == blockPos.x && it.y == blockPos.y && it.z == blockPos.z
@@ -1087,7 +1083,6 @@ class PacketHandler(
     }
 
     private fun sendBlockChanges() {
-        if(!Bullet.shouldPersist) return
         val blocks = world.modifiedBlocks
 
         for((position, metadata) in blocks) {
@@ -1122,8 +1117,6 @@ class PacketHandler(
     }
 
     private fun checkForBan(): Boolean {
-        if(!Bullet.shouldPersist) return false
-
         // Get ban or return true i
         val ban = Bullet.storage.getPlayerBan(client.player.uuid) ?: return false
 
@@ -1168,7 +1161,7 @@ class PacketHandler(
     private fun handleBlockPlacement(block: Block, event: BlockPlaceEvent, heldItem: Int) {
         val stateBlock = Block.getStateID(block)
 
-        if(Bullet.shouldPersist) event.player.world!!.modifiedBlocks[event.blockPos] = BlockWithMetadata(heldItem)
+        event.player.world!!.modifiedBlocks[event.blockPos] = BlockWithMetadata(heldItem)
 
         for(otherPlayer in Bullet.players) {
             if(otherPlayer != client.player) {
@@ -1196,10 +1189,10 @@ class PacketHandler(
 
         if(block in BlockTags.SIGNS) {
             client.sendPacket(ServerOpenSignEditorPacket(event.blockPos))
-            if(Bullet.shouldPersist) world.modifiedBlocks[event.blockPos] =
+            world.modifiedBlocks[event.blockPos] =
                 BlockWithMetadata(heldItem, listOf("", "", "", ""))
         } else {
-            if(Bullet.shouldPersist) world.modifiedBlocks[event.blockPos] = BlockWithMetadata(heldItem)
+            world.modifiedBlocks[event.blockPos] = BlockWithMetadata(heldItem)
         }
     }
 }

--- a/src/main/kotlin/storage/AbstractServerStorage.kt
+++ b/src/main/kotlin/storage/AbstractServerStorage.kt
@@ -1,0 +1,61 @@
+package com.aznos.storage
+
+import com.aznos.entity.player.Player
+import com.aznos.storage.world.AbstractWorldStorage
+import com.aznos.world.data.PlayerData
+import java.util.*
+
+interface AbstractServerStorage {
+
+    /**
+     * Get the world storage
+     *
+     * @param name The name of the world to load
+     * @return A world storage instance from this server storage
+     */
+    fun prepareWorldStorage(name: String): AbstractWorldStorage
+
+    /**
+     * Reads player data from the storage
+     *
+     * @param uuid The UUID of the player to read data for
+     * @return The player data that was read from the storage
+     */
+    fun readPlayerData(uuid: UUID): PlayerData
+
+    /**
+     * Writes player data to the storage, containing information like the player's location, health, food level, etc
+     *
+     * @param data The player data to save
+     * @return If the operation was successful
+     */
+    fun writePlayerData(data: PlayerData): Boolean
+
+    /**
+     * Writes player data to the disk, containing information like the player's location, health, food level, etc
+     *
+     * @param player The player to save its data
+     * @return If the operation was successful
+     */
+    fun writePlayerData(player: Player): Boolean {
+        return writePlayerData(
+            PlayerData(
+                player.username,
+                player.uuid,
+                player.location,
+                player.status.health,
+                player.status.foodLevel,
+                player.status.saturation,
+                player.status.exhaustion
+            )
+        )
+    }
+
+    /**
+     * Inform the storage system that the server is closing and should try to save everything now
+     *
+     * @return If the operation was successful
+     */
+    fun notifyClose(): Boolean
+
+}

--- a/src/main/kotlin/storage/AbstractServerStorage.kt
+++ b/src/main/kotlin/storage/AbstractServerStorage.kt
@@ -16,12 +16,12 @@ interface AbstractServerStorage {
     fun prepareWorldStorage(name: String): AbstractWorldStorage
 
     /**
-     * Reads player data from the storage
+     * Reads player data from the storage. null if absent
      *
      * @param uuid The UUID of the player to read data for
-     * @return The player data that was read from the storage
+     * @return The player data that was read from the storage or null if absent
      */
-    fun readPlayerData(uuid: UUID): PlayerData
+    fun readPlayerData(uuid: UUID): PlayerData?
 
     /**
      * Writes player data to the storage, containing information like the player's location, health, food level, etc
@@ -50,12 +50,5 @@ interface AbstractServerStorage {
             )
         )
     }
-
-    /**
-     * Inform the storage system that the server is closing and should try to save everything now
-     *
-     * @return If the operation was successful
-     */
-    fun notifyClose(): Boolean
 
 }

--- a/src/main/kotlin/storage/AbstractServerStorage.kt
+++ b/src/main/kotlin/storage/AbstractServerStorage.kt
@@ -31,7 +31,7 @@ interface AbstractServerStorage {
      * Writes player data to the storage, containing information like the player's location, health, food level, etc
      *
      * @param data The player data to save
-     * @return If the operation was successful
+     * @return Whether the operation was successful or not
      */
     fun writePlayerData(data: PlayerData): Boolean
 
@@ -39,7 +39,7 @@ interface AbstractServerStorage {
      * Writes player data to the disk, containing information like the player's location, health, food level, etc
      *
      * @param player The player to save its data
-     * @return If the operation was successful
+     * @return Whether the operation was successful or not
      */
     fun writePlayerData(player: Player): Boolean {
         return writePlayerData(
@@ -67,7 +67,7 @@ interface AbstractServerStorage {
      * Write player ban list to the storage
      *
      * @param banned A set of every banned players
-     * @return If the operation was successful
+     * @return Whether the operation was successful or not
      */
     fun writeBannedList(banned: Collection<BanData>): Boolean
 

--- a/src/main/kotlin/storage/AbstractServerStorage.kt
+++ b/src/main/kotlin/storage/AbstractServerStorage.kt
@@ -1,8 +1,10 @@
 package com.aznos.storage
 
 import com.aznos.entity.player.Player
+import com.aznos.entity.player.data.BanData
 import com.aznos.storage.world.AbstractWorldStorage
 import com.aznos.world.data.PlayerData
+import org.jetbrains.annotations.Contract
 import java.util.*
 
 interface AbstractServerStorage {
@@ -13,6 +15,7 @@ interface AbstractServerStorage {
      * @param name The name of the world to load
      * @return A world storage instance from this server storage
      */
+    @Contract(pure = true)
     fun prepareWorldStorage(name: String): AbstractWorldStorage
 
     /**
@@ -21,6 +24,7 @@ interface AbstractServerStorage {
      * @param uuid The UUID of the player to read data for
      * @return The player data that was read from the storage or null if absent
      */
+    @Contract(pure = true)
     fun readPlayerData(uuid: UUID): PlayerData?
 
     /**
@@ -50,5 +54,22 @@ interface AbstractServerStorage {
             )
         )
     }
+
+    /**
+     * Read player ban list from the storage
+     *
+     * @return A set containing all the id of currently banned player
+     */
+    @Contract(pure = true)
+    fun readBannedList(): Collection<BanData>
+
+    /**
+     * Write player ban list to the storage
+     *
+     * @param banned A set of every banned players
+     * @return If the operation was successful
+     */
+    fun writeBannedList(banned: Collection<BanData>): Boolean
+
 
 }

--- a/src/main/kotlin/storage/EmptyStorage.kt
+++ b/src/main/kotlin/storage/EmptyStorage.kt
@@ -1,0 +1,68 @@
+package com.aznos.storage
+
+import com.aznos.datatypes.BlockPositionType
+import com.aznos.entity.player.Player
+import com.aznos.entity.player.data.BanData
+import com.aznos.storage.world.AbstractWorldStorage
+import com.aznos.world.World
+import com.aznos.world.data.BlockWithMetadata
+import com.aznos.world.data.PlayerData
+import com.aznos.world.data.WorldData
+import java.util.*
+
+/**
+ * Represent an empty storage that do not store modifications
+ */
+class EmptyStorage : AbstractServerStorage {
+    override fun prepareWorldStorage(name: String): AbstractWorldStorage {
+        return EmptyWorldStorage(name)
+    }
+
+    override fun readPlayerData(uuid: UUID): PlayerData? {
+        return null
+    }
+
+    override fun writePlayerData(data: PlayerData): Boolean {
+        return true
+    }
+
+    override fun writePlayerData(player: Player): Boolean {
+        return true
+    }
+
+    override fun readBannedList(): Collection<BanData> {
+        return Collections.emptyList()
+    }
+
+    override fun writeBannedList(banned: Collection<BanData>): Boolean {
+        return true
+    }
+
+    class EmptyWorldStorage(private val name: String) : AbstractWorldStorage {
+        override fun getName(): String {
+            return name
+        }
+
+        override fun readWorldData(): WorldData? {
+            return null
+        }
+
+        override fun writeWorldData(data: WorldData): Boolean {
+            return true
+        }
+
+        override fun writeWorldData(world: World): Boolean {
+            return true
+        }
+
+        override fun readBlockData(): MutableMap<BlockPositionType.BlockPosition, BlockWithMetadata> {
+            return mutableMapOf()
+        }
+
+        override fun writeBlockData(modifiedBlocks: MutableMap<BlockPositionType.BlockPosition, BlockWithMetadata>): Boolean {
+            return true
+        }
+
+    }
+
+}

--- a/src/main/kotlin/storage/EmptyStorage.kt
+++ b/src/main/kotlin/storage/EmptyStorage.kt
@@ -59,7 +59,9 @@ class EmptyStorage : AbstractServerStorage {
             return mutableMapOf()
         }
 
-        override fun writeBlockData(modifiedBlocks: MutableMap<BlockPositionType.BlockPosition, BlockWithMetadata>): Boolean {
+        override fun writeBlockData(
+            modifiedBlocks: MutableMap<BlockPositionType.BlockPosition, BlockWithMetadata>
+        ): Boolean {
             return true
         }
 

--- a/src/main/kotlin/storage/StorageManager.kt
+++ b/src/main/kotlin/storage/StorageManager.kt
@@ -1,0 +1,37 @@
+package com.aznos.storage
+
+import com.aznos.world.World
+
+class StorageManager(val storage: AbstractServerStorage) {
+
+    private val worlds = HashMap<String, World>()
+
+    /**
+     * Get world with by name if exist
+     *
+     * @param name the world's name
+     * @return the world with that name. null if do not exist
+     */
+    fun getWorld(name: String): World? {
+        return worlds[name]
+    }
+
+    /**
+     * Get world with by name.
+     * Will load and create a new world if already exist
+     *
+     * @param name the world's name
+     * @return the world with that name
+     */
+    fun getOrLoadWorld(name: String): World {
+        if (worlds.containsKey(name)) return worlds[name]!!
+
+        val worldStorage = storage.prepareWorldStorage(name)
+        val data = worldStorage.readWorldData()
+
+        // TODO create world from data
+        return World(name)
+    }
+
+
+}

--- a/src/main/kotlin/storage/disk/DiskServerStorage.kt
+++ b/src/main/kotlin/storage/disk/DiskServerStorage.kt
@@ -1,20 +1,24 @@
 package com.aznos.storage.disk
 
 import com.aznos.Bullet
+import com.aznos.entity.player.data.BanData
 import com.aznos.storage.AbstractServerStorage
+import com.aznos.storage.disk.DiskStorageUtil.readFileData
+import com.aznos.storage.disk.DiskStorageUtil.writeFileData
 import com.aznos.storage.world.AbstractWorldStorage
 import com.aznos.world.data.PlayerData
-import kotlinx.serialization.json.Json
 import java.io.File
-import java.nio.file.Files
 import java.util.*
 
 class DiskServerStorage : AbstractServerStorage {
 
     companion object {
-        private val STORAGE_ROOT = File(".")
+        private val STORAGE_ROOT = File("./data")
+
         private val WORLDS_STORAGE_ROOT = File(STORAGE_ROOT, "worlds")
         private val PLAYER_STORAGE_ROOT = File(STORAGE_ROOT, "players")
+
+        private const val BANNED_FILE_NAME = "banned_players.json"
     }
 
     override fun prepareWorldStorage(name: String): AbstractWorldStorage {
@@ -23,22 +27,24 @@ class DiskServerStorage : AbstractServerStorage {
 
     override fun readPlayerData(uuid: UUID): PlayerData? {
         val file = File(PLAYER_STORAGE_ROOT, "$uuid.json")
-        if (!file.exists()) return null
-
-        val json = Files.readString(file.toPath())
-        return Json.decodeFromString(json)
+        return readFileData(file, null)
     }
 
     override fun writePlayerData(data: PlayerData): Boolean {
         assert(Bullet.shouldPersist) // We only want to save if persistence is enabled
 
-        PLAYER_STORAGE_ROOT.mkdirs()
         val file = File(PLAYER_STORAGE_ROOT, "${data.uuid}.json")
-        if (!file.exists()) file.createNewFile()
+        return writeFileData(file, data)
+    }
 
-        val json = Json.encodeToString(data)
-        Files.write(file.toPath(), json.toByteArray())
-        return true
+    override fun readBannedList(): Collection<BanData> {
+        val file = File(STORAGE_ROOT, BANNED_FILE_NAME)
+        return readFileData(file, Collections.emptyList())
+    }
+
+    override fun writeBannedList(banned: Collection<BanData>): Boolean {
+        val file = File(STORAGE_ROOT, BANNED_FILE_NAME)
+        return writeFileData(file, banned)
     }
 
 }

--- a/src/main/kotlin/storage/disk/DiskServerStorage.kt
+++ b/src/main/kotlin/storage/disk/DiskServerStorage.kt
@@ -31,8 +31,6 @@ class DiskServerStorage : AbstractServerStorage {
     }
 
     override fun writePlayerData(data: PlayerData): Boolean {
-        assert(Bullet.shouldPersist) // We only want to save if persistence is enabled
-
         val file = File(PLAYER_STORAGE_ROOT, "${data.uuid}.json")
         return writeFileData(file, data)
     }

--- a/src/main/kotlin/storage/disk/DiskServerStorage.kt
+++ b/src/main/kotlin/storage/disk/DiskServerStorage.kt
@@ -1,0 +1,44 @@
+package com.aznos.storage.disk
+
+import com.aznos.Bullet
+import com.aznos.storage.AbstractServerStorage
+import com.aznos.storage.world.AbstractWorldStorage
+import com.aznos.world.data.PlayerData
+import kotlinx.serialization.json.Json
+import java.io.File
+import java.nio.file.Files
+import java.util.*
+
+class DiskServerStorage : AbstractServerStorage {
+
+    companion object {
+        private val STORAGE_ROOT = File(".")
+        private val WORLDS_STORAGE_ROOT = File(STORAGE_ROOT, "worlds")
+        private val PLAYER_STORAGE_ROOT = File(STORAGE_ROOT, "players")
+    }
+
+    override fun prepareWorldStorage(name: String): AbstractWorldStorage {
+        return DiskWorldStorage(name, File(WORLDS_STORAGE_ROOT, name))
+    }
+
+    override fun readPlayerData(uuid: UUID): PlayerData? {
+        val file = File(PLAYER_STORAGE_ROOT, "$uuid.json")
+        if (!file.exists()) return null
+
+        val json = Files.readString(file.toPath())
+        return Json.decodeFromString(json)
+    }
+
+    override fun writePlayerData(data: PlayerData): Boolean {
+        assert(Bullet.shouldPersist) // We only want to save if persistence is enabled
+
+        PLAYER_STORAGE_ROOT.mkdirs()
+        val file = File(PLAYER_STORAGE_ROOT, "${data.uuid}.json")
+        if (!file.exists()) file.createNewFile()
+
+        val json = Json.encodeToString(data)
+        Files.write(file.toPath(), json.toByteArray())
+        return true
+    }
+
+}

--- a/src/main/kotlin/storage/disk/DiskStorageUtil.kt
+++ b/src/main/kotlin/storage/disk/DiskStorageUtil.kt
@@ -1,0 +1,57 @@
+package com.aznos.storage.disk
+
+import com.aznos.Bullet
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
+import java.io.File
+import java.nio.file.Files
+
+object DiskStorageUtil {
+
+    val json = Json { allowStructuredMapKeys = true }
+
+    /**
+     * Deserialize file and use default if could not read it
+     *
+     * @param T The type of the object to deserialize
+     * @param file The file to read the object from
+     * @param default The used value if the file content is empty or an error happens
+     * @return The deserialized data if could deserialize, "default" otherwise
+     */
+    inline fun <reified T> readFileData(file: File, default: T): T {
+        if (!file.exists()) return default
+
+        val jsonData = Files.readString(file.toPath())
+        if (jsonData.isEmpty()) {
+            Bullet.logger.warn("Data of file ${file.path} is empty")
+            return default
+        }
+
+        return try {
+            json.decodeFromString<T>(jsonData)
+        } catch (e: SerializationException) {
+            Bullet.logger.error("Could not read file ${file.path}", e)
+            default
+        } catch (e: IllegalArgumentException) {
+            Bullet.logger.error("Could not read file ${file.path}", e)
+            default
+        }
+    }
+
+    /**
+     * Writes serialized data to the file
+     *
+     * @param file The file to save the data to
+     * @param data The data to save
+     * @return If the operation was successful
+     */
+    inline fun <reified T> writeFileData(file: File, data: T): Boolean {
+        file.parentFile.mkdirs()
+        if (!file.exists()) file.createNewFile()
+
+        val jsonData = json.encodeToString(data)
+        Files.write(file.toPath(), jsonData.toByteArray())
+        return true
+    }
+
+}

--- a/src/main/kotlin/storage/disk/DiskWorldStorage.kt
+++ b/src/main/kotlin/storage/disk/DiskWorldStorage.kt
@@ -1,6 +1,5 @@
 package com.aznos.storage.disk
 
-import com.aznos.Bullet
 import com.aznos.datatypes.BlockPositionType
 import com.aznos.storage.disk.DiskStorageUtil.readFileData
 import com.aznos.storage.disk.DiskStorageUtil.writeFileData
@@ -29,8 +28,6 @@ class DiskWorldStorage(
     }
 
     override fun writeWorldData(data: WorldData): Boolean {
-        assert(Bullet.shouldPersist) // We only want to save if persistence is enabled
-
         val file = File(folder, WORLD_DATA_FILE_NAME)
         return writeFileData(file, data)
     }

--- a/src/main/kotlin/storage/disk/DiskWorldStorage.kt
+++ b/src/main/kotlin/storage/disk/DiskWorldStorage.kt
@@ -1,0 +1,39 @@
+package com.aznos.storage.disk
+
+import com.aznos.Bullet
+import com.aznos.storage.world.AbstractWorldStorage
+import com.aznos.world.data.WorldData
+import kotlinx.serialization.json.Json
+import java.io.File
+import java.nio.file.Files
+
+class DiskWorldStorage(
+    private val name: String,
+    private val folder: File,
+) : AbstractWorldStorage {
+
+    override fun getName(): String {
+        return name
+    }
+
+    override fun writeWorldData(data: WorldData): Boolean {
+        assert(Bullet.shouldPersist) // We only want to save if persistence is enabled
+
+        folder.mkdirs()
+        val file = File(folder, "world.json")
+        if (!file.exists()) file.createNewFile()
+
+        val json = Json.encodeToString(data)
+        Files.write(file.toPath(), json.toByteArray())
+        return true
+    }
+
+    override fun readWorldData(): WorldData? {
+        val file = File(folder, "world.json")
+        if (!file.exists()) return null
+
+        val json = Files.readString(file.toPath())
+        return Json.decodeFromString(json)
+    }
+
+}

--- a/src/main/kotlin/storage/disk/DiskWorldStorage.kt
+++ b/src/main/kotlin/storage/disk/DiskWorldStorage.kt
@@ -1,39 +1,35 @@
 package com.aznos.storage.disk
 
 import com.aznos.Bullet
+import com.aznos.storage.disk.DiskStorageUtil.readFileData
+import com.aznos.storage.disk.DiskStorageUtil.writeFileData
 import com.aznos.storage.world.AbstractWorldStorage
 import com.aznos.world.data.WorldData
-import kotlinx.serialization.json.Json
 import java.io.File
-import java.nio.file.Files
 
 class DiskWorldStorage(
     private val name: String,
     private val folder: File,
 ) : AbstractWorldStorage {
 
+    companion object {
+        private const val WORLD_FILE_NAME = "world.json"
+    }
+
     override fun getName(): String {
         return name
+    }
+
+    override fun readWorldData(): WorldData? {
+        val file = File(folder, WORLD_FILE_NAME)
+        return readFileData(file, null)
     }
 
     override fun writeWorldData(data: WorldData): Boolean {
         assert(Bullet.shouldPersist) // We only want to save if persistence is enabled
 
-        folder.mkdirs()
-        val file = File(folder, "world.json")
-        if (!file.exists()) file.createNewFile()
-
-        val json = Json.encodeToString(data)
-        Files.write(file.toPath(), json.toByteArray())
-        return true
-    }
-
-    override fun readWorldData(): WorldData? {
-        val file = File(folder, "world.json")
-        if (!file.exists()) return null
-
-        val json = Files.readString(file.toPath())
-        return Json.decodeFromString(json)
+        val file = File(folder, WORLD_FILE_NAME)
+        return writeFileData(file, data)
     }
 
 }

--- a/src/main/kotlin/storage/disk/DiskWorldStorage.kt
+++ b/src/main/kotlin/storage/disk/DiskWorldStorage.kt
@@ -1,9 +1,11 @@
 package com.aznos.storage.disk
 
 import com.aznos.Bullet
+import com.aznos.datatypes.BlockPositionType
 import com.aznos.storage.disk.DiskStorageUtil.readFileData
 import com.aznos.storage.disk.DiskStorageUtil.writeFileData
 import com.aznos.storage.world.AbstractWorldStorage
+import com.aznos.world.data.BlockWithMetadata
 import com.aznos.world.data.WorldData
 import java.io.File
 
@@ -13,7 +15,8 @@ class DiskWorldStorage(
 ) : AbstractWorldStorage {
 
     companion object {
-        private const val WORLD_FILE_NAME = "world.json"
+        private const val WORLD_DATA_FILE_NAME = "world.json"
+        private const val WORLD_STORAGE_FILE_NAME = "blocks.json"
     }
 
     override fun getName(): String {
@@ -21,15 +24,25 @@ class DiskWorldStorage(
     }
 
     override fun readWorldData(): WorldData? {
-        val file = File(folder, WORLD_FILE_NAME)
+        val file = File(folder, WORLD_DATA_FILE_NAME)
         return readFileData(file, null)
     }
 
     override fun writeWorldData(data: WorldData): Boolean {
         assert(Bullet.shouldPersist) // We only want to save if persistence is enabled
 
-        val file = File(folder, WORLD_FILE_NAME)
+        val file = File(folder, WORLD_DATA_FILE_NAME)
         return writeFileData(file, data)
+    }
+
+    override fun readBlockData(): MutableMap<BlockPositionType.BlockPosition, BlockWithMetadata> {
+        val file = File(folder, WORLD_STORAGE_FILE_NAME)
+        return readFileData(file, HashMap())
+    }
+
+    override fun writeBlockData(modifiedBlocks: MutableMap<BlockPositionType.BlockPosition, BlockWithMetadata>): Boolean {
+        val file = File(folder, WORLD_STORAGE_FILE_NAME)
+        return writeFileData(file, modifiedBlocks)
     }
 
 }

--- a/src/main/kotlin/storage/disk/DiskWorldStorage.kt
+++ b/src/main/kotlin/storage/disk/DiskWorldStorage.kt
@@ -37,7 +37,9 @@ class DiskWorldStorage(
         return readFileData(file, HashMap())
     }
 
-    override fun writeBlockData(modifiedBlocks: MutableMap<BlockPositionType.BlockPosition, BlockWithMetadata>): Boolean {
+    override fun writeBlockData(
+        modifiedBlocks: MutableMap<BlockPositionType.BlockPosition, BlockWithMetadata>
+    ): Boolean {
         val file = File(folder, WORLD_STORAGE_FILE_NAME)
         return writeFileData(file, modifiedBlocks)
     }

--- a/src/main/kotlin/storage/world/AbstractWorldStorage.kt
+++ b/src/main/kotlin/storage/world/AbstractWorldStorage.kt
@@ -53,11 +53,14 @@ interface AbstractWorldStorage {
     fun readBlockData(): MutableMap<BlockPositionType.BlockPosition, BlockWithMetadata>
 
     /**
-     * Writes block data to the storage, containing information about all the blocks that have been modified in the world
+     * Writes block data to the storage.
+     * containing information about all the blocks that have been modified in the world
      *
      * @param modifiedBlocks A map of all the blocks that have been modified in the world
      * @return Whether the operation was successful or not
      */
-    fun writeBlockData(modifiedBlocks: MutableMap<BlockPositionType.BlockPosition, BlockWithMetadata>): Boolean
+    fun writeBlockData(
+        modifiedBlocks: MutableMap<BlockPositionType.BlockPosition, BlockWithMetadata>
+    ): Boolean
 
 }

--- a/src/main/kotlin/storage/world/AbstractWorldStorage.kt
+++ b/src/main/kotlin/storage/world/AbstractWorldStorage.kt
@@ -15,6 +15,7 @@ interface AbstractWorldStorage {
     /**
      * Writes world data to the storage, containing information like the difficulty of the world, time of day, etc
      * so that it can be loaded back in when the server restarts
+     * Note: this function has no guarantee that the player data is saved immediately
      *
      * @param data The world data to write to storage
      * @return A world storage instance from this server storage
@@ -24,6 +25,7 @@ interface AbstractWorldStorage {
     /**
      * Writes world data to the storage, containing information like the difficulty of the world, time of day, etc
      * so that it can be loaded back in when the server restarts
+     * Note: this function has no guarantee that the player data is saved immediately
      *
      * @param world The world to write to storage
      * @return A world storage instance from this server storage
@@ -35,19 +37,12 @@ interface AbstractWorldStorage {
     }
 
     /**
-     * Reads world data from the storage
+     * Reads world data from the storage if exist
      *
-     * @return The world data that was read from the storage
+     * @return The world data that was read from the storage. null if do not exist
      */
-    fun readWorldData(): WorldData
+    fun readWorldData(): WorldData?
 
     // todo block/chunk load & save
-
-    /**
-     * Inform the storage system that the server is closing and should try to save everything now
-     *
-     * @return A world storage instance from this server storage
-     */
-    fun notifyClose(): Boolean
 
 }

--- a/src/main/kotlin/storage/world/AbstractWorldStorage.kt
+++ b/src/main/kotlin/storage/world/AbstractWorldStorage.kt
@@ -1,6 +1,8 @@
 package com.aznos.storage.world
 
+import com.aznos.datatypes.BlockPositionType
 import com.aznos.world.World
+import com.aznos.world.data.BlockWithMetadata
 import com.aznos.world.data.WorldData
 
 interface AbstractWorldStorage {
@@ -18,7 +20,7 @@ interface AbstractWorldStorage {
      * Note: this function has no guarantee that the player data is saved immediately
      *
      * @param data The world data to write to storage
-     * @return A world storage instance from this server storage
+     * @return Whether the operation was successful or not
      */
     fun writeWorldData(data: WorldData): Boolean
 
@@ -28,7 +30,7 @@ interface AbstractWorldStorage {
      * Note: this function has no guarantee that the player data is saved immediately
      *
      * @param world The world to write to storage
-     * @return A world storage instance from this server storage
+     * @return Whether the operation was successful or not
      */
     fun writeWorldData(
         world: World
@@ -43,6 +45,19 @@ interface AbstractWorldStorage {
      */
     fun readWorldData(): WorldData?
 
-    // todo block/chunk load & save
+    /**
+     * Reads block data from the storage if exist
+     *
+     * @return A map of all the blocks that have been modified in the world
+     */
+    fun readBlockData(): MutableMap<BlockPositionType.BlockPosition, BlockWithMetadata>
+
+    /**
+     * Writes block data to the storage, containing information about all the blocks that have been modified in the world
+     *
+     * @param modifiedBlocks A map of all the blocks that have been modified in the world
+     * @return Whether the operation was successful or not
+     */
+    fun writeBlockData(modifiedBlocks: MutableMap<BlockPositionType.BlockPosition, BlockWithMetadata>): Boolean
 
 }

--- a/src/main/kotlin/storage/world/AbstractWorldStorage.kt
+++ b/src/main/kotlin/storage/world/AbstractWorldStorage.kt
@@ -1,0 +1,53 @@
+package com.aznos.storage.world
+
+import com.aznos.world.World
+import com.aznos.world.data.WorldData
+
+interface AbstractWorldStorage {
+
+    /**
+     * Get the world name related to this storage
+     *
+     * @return The world name linked to this storage
+     */
+    fun getName(): String
+
+    /**
+     * Writes world data to the storage, containing information like the difficulty of the world, time of day, etc
+     * so that it can be loaded back in when the server restarts
+     *
+     * @param data The world data to write to storage
+     * @return A world storage instance from this server storage
+     */
+    fun writeWorldData(data: WorldData): Boolean
+
+    /**
+     * Writes world data to the storage, containing information like the difficulty of the world, time of day, etc
+     * so that it can be loaded back in when the server restarts
+     *
+     * @param world The world to write to storage
+     * @return A world storage instance from this server storage
+     */
+    fun writeWorldData(
+        world: World
+    ): Boolean {
+        return writeWorldData(WorldData(world.difficulty.id, world.weather == 1, world.timeOfDay))
+    }
+
+    /**
+     * Reads world data from the storage
+     *
+     * @return The world data that was read from the storage
+     */
+    fun readWorldData(): WorldData
+
+    // todo block/chunk load & save
+
+    /**
+     * Inform the storage system that the server is closing and should try to save everything now
+     *
+     * @return A world storage instance from this server storage
+     */
+    fun notifyClose(): Boolean
+
+}

--- a/src/main/kotlin/storage/world/AbstractWorldStorage.kt
+++ b/src/main/kotlin/storage/world/AbstractWorldStorage.kt
@@ -15,6 +15,13 @@ interface AbstractWorldStorage {
     fun getName(): String
 
     /**
+     * Reads world data from the storage if exist
+     *
+     * @return The world data that was read from the storage. null if do not exist
+     */
+    fun readWorldData(): WorldData?
+
+    /**
      * Writes world data to the storage, containing information like the difficulty of the world, time of day, etc
      * so that it can be loaded back in when the server restarts
      * Note: this function has no guarantee that the player data is saved immediately
@@ -37,13 +44,6 @@ interface AbstractWorldStorage {
     ): Boolean {
         return writeWorldData(WorldData(world.difficulty.id, world.weather == 1, world.timeOfDay))
     }
-
-    /**
-     * Reads world data from the storage if exist
-     *
-     * @return The world data that was read from the storage. null if do not exist
-     */
-    fun readWorldData(): WorldData?
 
     /**
      * Reads block data from the storage if exist

--- a/src/main/kotlin/world/World.kt
+++ b/src/main/kotlin/world/World.kt
@@ -1,12 +1,10 @@
 package com.aznos.world
 
-import com.aznos.Bullet.shouldPersist
 import com.aznos.datatypes.BlockPositionType
 import com.aznos.storage.world.AbstractWorldStorage
 import com.aznos.world.data.BlockWithMetadata
 import com.aznos.world.data.Difficulty
 import com.aznos.world.data.TimeOfDay
-import kotlinx.serialization.json.Json
 
 /**
  * Represents a world in the game
@@ -36,7 +34,8 @@ class World(
     }
 
     private fun loadWorldsData() {
-        if (!shouldPersist) return
+        this.modifiedBlocks = storage.readBlockData()
+
         val data = storage.readWorldData() ?: return
 
         val difficulty = Difficulty.getDifficultyFromID(data.difficulty)
@@ -44,8 +43,6 @@ class World(
         this.difficulty = difficulty
         this.weather = if (data.raining) 1 else 0
         this.timeOfDay = data.timeOfDay
-
-        this.modifiedBlocks = storage.readBlockData()
     }
 
     fun save() {

--- a/src/main/kotlin/world/World.kt
+++ b/src/main/kotlin/world/World.kt
@@ -72,12 +72,6 @@ class World(
 
         createFileIfNotExists(Paths.get("./$name/data/blocks.json"))
 
-        val banFile = Paths.get("./$name/data/banned_players.json")
-        createFileIfNotExists(banFile)
-        if(Files.size(banFile) == 0L) {
-            Files.write(banFile, "[]".toByteArray())
-        }
-
         return true
     }
 
@@ -100,56 +94,6 @@ class World(
      */
     fun readBlockData(): MutableMap<BlockPositionType.BlockPosition, BlockWithMetadata> {
         val path = Paths.get("./$name/data/blocks.json")
-        val jsonData = Files.readString(path)
-        return json.decodeFromString(jsonData)
-    }
-
-    fun writeBannedPlayer(
-        player: UUID,
-        reason: String,
-        duration: Duration,
-        moderator: UUID
-    ) {
-        createFiles()
-
-        val path = Paths.get("./$name/data/banned_players.json")
-        val currentBans: MutableList<BanData> = if(Files.exists(path)) {
-            try {
-                val jsonData = Files.readString(path)
-                Json.decodeFromString(jsonData)
-            } catch(e: IOException) {
-                mutableListOf()
-            }
-        } else mutableListOf()
-
-        currentBans.removeIf { it.uuid == player }
-        currentBans.add(BanData(player, reason, duration, System.currentTimeMillis(), moderator))
-
-        val newJson = Json.encodeToString(currentBans)
-        Files.write(path, newJson.toByteArray())
-    }
-
-    fun unbanPlayer(player: UUID) {
-        createFiles()
-
-        val path = Paths.get("./$name/data/banned_players.json")
-        val currentBans: MutableList<BanData> = if(Files.exists(path)) {
-            try {
-                val jsonData = Files.readString(path)
-                Json.decodeFromString(jsonData)
-            } catch(e: IOException) {
-                mutableListOf()
-            }
-        } else mutableListOf()
-
-        currentBans.removeIf { it.uuid == player }
-
-        val newJson = Json.encodeToString(currentBans)
-        Files.write(path, newJson.toByteArray())
-    }
-
-    fun readBannedPlayers(): List<BanData> {
-        val path = Paths.get("./$name/data/banned_players.json")
         val jsonData = Files.readString(path)
         return json.decodeFromString(jsonData)
     }

--- a/src/main/kotlin/world/World.kt
+++ b/src/main/kotlin/world/World.kt
@@ -1,21 +1,15 @@
 package com.aznos.world
 
 import com.aznos.Bullet.shouldPersist
-import com.aznos.Bullet.world
 import com.aznos.datatypes.BlockPositionType
-import com.aznos.datatypes.LocationType
-import com.aznos.entity.player.data.BanData
 import com.aznos.storage.world.AbstractWorldStorage
 import com.aznos.world.data.BlockWithMetadata
 import com.aznos.world.data.Difficulty
 import com.aznos.world.data.TimeOfDay
 import kotlinx.serialization.json.Json
-import java.io.IOException
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
-import java.util.*
-import kotlin.time.Duration
 
 /**
  * Represents a world in the game
@@ -122,6 +116,6 @@ class World(
 
     fun save() {
         storage.writeWorldData(this)
-        world.writeBlockData(world.modifiedBlocks)
+        writeBlockData(modifiedBlocks)
     }
 }

--- a/src/main/kotlin/world/data/Difficulty.kt
+++ b/src/main/kotlin/world/data/Difficulty.kt
@@ -4,5 +4,15 @@ enum class Difficulty(val id: Int) {
     PEACEFUL(0),
     EASY(1),
     NORMAL(2),
-    HARD(3)
+    HARD(3),
+    ;
+
+    companion object {
+        // Note: only works as id is in the same order as difficulties order
+        fun getDifficultyFromID(id: Int, default: Difficulty = NORMAL): Difficulty {
+            return entries[id.takeIf { it >= 0 && it < entries.size} ?: default.id]
+        }
+
+    }
+
 }


### PR DESCRIPTION
Add an abstraction layer over the save system to easily add/remove components & add possibility of multiples way to save things (aka easy to add save over DB instead of file for example)
Make server marked as non-persistent use this system
Make support for multiples worlds being run (even if only world [0] is currently accessible by the player)